### PR TITLE
Migrate to latest Google Maps API (and update other Google/Gradle deps)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
 
         classpath "io.realm:realm-gradle-plugin:1.0.0"
     }

--- a/example/app/build.gradle
+++ b/example/app/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'realm-android'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "co.moonmonkeylabs.realmmap.example"
         minSdkVersion 15
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -22,7 +22,7 @@ android {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.4.0'
+    compile 'com.android.support:appcompat-v7:25.3.1'
 
 //    compile project(':library')
     compile 'com.github.thorbenprimke:realm-map:0.9.2'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
 
         classpath "io.realm:realm-gradle-plugin:1.0.0"
     }

--- a/example/gradle/wrapper/gradle-wrapper.properties
+++ b/example/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon May 30 15:34:03 PDT 2016
+#Mon Apr 10 13:45:28 BST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon May 30 16:12:29 PDT 2016
+#Mon Apr 10 21:21:47 BST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'realm-android'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -20,7 +20,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:recyclerview-v7:23.4.0'
-    compile 'com.google.maps.android:android-maps-utils:0.4.3'
-    compile 'com.google.android.gms:play-services-maps:9.0.1'
+    compile 'com.android.support:recyclerview-v7:25.3.1'
+    compile 'com.google.maps.android:android-maps-utils:0.5'
+    compile 'com.google.android.gms:play-services-maps:10.2.1'
 }

--- a/library/src/main/java/io/realm/RealmClusterManager.java
+++ b/library/src/main/java/io/realm/RealmClusterManager.java
@@ -22,8 +22,6 @@ import io.realm.internal.Table;
 public class RealmClusterManager<M extends RealmObject>
         extends ClusterManager<RealmClusterWrapper<M>> {
 
-    private long titleColumnIndex = -1;
-
     public RealmClusterManager(Context context, GoogleMap map) {
         super(context, map);
     }
@@ -50,7 +48,7 @@ public class RealmClusterManager<M extends RealmObject>
         super.clearItems();
         final Table table = realmResults.getTable().getTable();
 
-        titleColumnIndex = table.getColumnIndex(titleColumnName);
+        long titleColumnIndex = table.getColumnIndex(titleColumnName);
         if (titleColumnIndex == Table.NO_MATCH) {
             throw new IllegalStateException("titleColumnName not valid.");
         }

--- a/library/src/main/java/io/realm/RealmClusterWrapper.java
+++ b/library/src/main/java/io/realm/RealmClusterWrapper.java
@@ -32,4 +32,9 @@ public class RealmClusterWrapper<T extends RealmObject> implements ClusterItem {
     public String getTitle() {
         return title;
     }
+
+    @Override
+    public String getSnippet() {
+        return null;
+    }
 }


### PR DESCRIPTION
Resolves Issue #12

- Update to latest play-services-maps & android-maps-utils
- Migrate from removed getMap() to getMapAsync():
    - Add OnMapReadyCallback to configure the Map behaviour
    - Delay restoring camera position/zoom until Map is ready
- Use ClusterManager’s setOnCameraIdleListener() rather than deprecated
setOnCameraChangeListener()
- ClusterItem interface now requires implementation of getSnippet(),
which can return null (no snippet is displayed). RealmClusterWrapper
could be updated to add a snippet, but the sample data used by the
example app doesn’t have any unused columns.
- Update SDK, support & build tools versions to 25 / 25.3.1
- Update gradle plugin to 2.3.1, and gradle to 3.3.
- Fix a few Lint warnings